### PR TITLE
Integrate useful ramps

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -2668,7 +2668,7 @@
     "tools": [ [ [ "con_mix", 125 ] ] ],
     "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
     "components": [ [ [ "concrete", 5 ] ], [ [ "water", 5 ] ] ],
-    "pre_terrain": "t_pit_shallow",
+    "pre_terrain": "check_empty",
     "pre_special": "check_ramp_low",
     "post_terrain": "t_ramp_up_low",
     "post_special": "done_ramp_low"
@@ -2685,7 +2685,7 @@
     "tools": [ [ [ "con_mix", 125 ] ] ],
     "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
     "components": [ [ [ "concrete", 5 ] ], [ [ "water", 5 ] ] ],
-    "pre_terrain": "t_pit_shallow",
+    "pre_terrain": "check_empty",
     "pre_special": "check_ramp_high",
     "post_terrain": "t_ramp_up_high",
     "post_special": "done_ramp_high"


### PR DESCRIPTION
#### Summary
Balance "Added "Useful ramps" to vanilla"

#### Purpose of change

Useful ramps allows to build ramps almost everywhere.

#### Describe the solution

Changed requirements to build ramps from shallow pit to flat land.

#### Describe alternatives you've considered


#### Testing

You can build ramps on roofs, underground, etc. No pit required.

#### Additional context