### PR TITLE
Increate Plate armor cover to 98%

### DIFF
--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -226,7 +226,7 @@
     "looks_like": "armor_larmor",
     "color": "light_gray",
     "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
-    "coverage": 95,
+    "coverage": 98,
     "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 4,


### PR DESCRIPTION
A 5% chance to randomly hit plate armor joints is too high and unrealistic.
